### PR TITLE
feat(organsation-card): create organisation card

### DIFF
--- a/pkg/app/src/@types/bodydata.d.ts
+++ b/pkg/app/src/@types/bodydata.d.ts
@@ -1,0 +1,7 @@
+export interface BodyData {
+	access: number
+	cid: string
+	id: string
+	members: any
+	name: string
+}

--- a/pkg/app/src/@types/ipfsmetadata.d.ts
+++ b/pkg/app/src/@types/ipfsmetadata.d.ts
@@ -1,0 +1,8 @@
+export interface IpfsMetadata {
+	description: string
+	email: string
+	logo: string
+	name: string
+	repo: string
+	website: string
+}

--- a/pkg/app/src/components/OrganisationCard/item.tsx
+++ b/pkg/app/src/components/OrganisationCard/item.tsx
@@ -1,0 +1,25 @@
+import React, { useState, useEffect } from 'react'
+import { BodyData } from 'src/@types/bodydata'
+import { IpfsMetadata } from 'src/@types/ipfsmetadata'
+
+import { fetchIpfsJson } from 'src/utils/ipfs'
+
+import { TileCard } from './modules/tileCard'
+
+interface ComponentProps {
+	item: BodyData
+}
+
+export function Item({ item }: ComponentProps) {
+	const [metadata, setMetadata] = useState<IpfsMetadata>(null)
+
+	useEffect(() => {
+		const fetch = async () => {
+			let result = await fetchIpfsJson(item?.cid)
+			setMetadata(result)
+		}
+		fetch()
+	}, [item])
+
+	return <TileCard metadata={metadata} item={item}></TileCard>
+}

--- a/pkg/app/src/components/OrganisationCard/itemList.tsx
+++ b/pkg/app/src/components/OrganisationCard/itemList.tsx
@@ -1,0 +1,21 @@
+import { Grid } from '@mui/material'
+import { BodyData } from 'src/@types/bodydata'
+import { Item } from './item'
+
+interface ComponentProps {
+	items: readonly BodyData[]
+}
+
+export function ItemList({ items }: ComponentProps) {
+	if (!Array.isArray(items)) return null
+
+	return (
+		<Grid container spacing={{ xs: 2, md: 3 }} columns={{ xs: 4, sm: 8, md: 12 }}>
+			{items?.map((itemData, index) => (
+				<Grid item xs={4} sm={4} md={6} key={index}>
+					<Item item={itemData} />
+				</Grid>
+			))}
+		</Grid>
+	)
+}

--- a/pkg/app/src/components/OrganisationCard/modules/tileCard.tsx
+++ b/pkg/app/src/components/OrganisationCard/modules/tileCard.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from 'react'
+import { useExtensionContext } from 'src/provider/extension/modules/context'
+import { NavLink } from 'src/components/NavLink/navLink'
+import { BodyData } from 'src/@types/bodydata'
+import { IpfsMetadata } from 'src/@types/ipfsmetadata'
+import { useTheme } from '@mui/material/styles'
+import { Typography, Card, Box, CardHeader, CardContent, Avatar } from '@mui/material'
+import { Person, Key, KeyOff, Check } from '@mui/icons-material'
+
+interface ComponentsPros {
+	item: BodyData
+	metadata: IpfsMetadata
+}
+
+const gateway = 'https://ipfs.gamedao.co/gateway/'
+const toLink = '/app/organisations/'
+
+export const TileCard = ({ item, metadata }: ComponentsPros) => {
+	const { selectedAccount } = useExtensionContext()
+	const theme = useTheme()
+	const bgPlain = { backgroundColor: theme.palette.grey[500_16] }
+	const address = selectedAccount?.account.address
+
+	const SubHeader = useMemo(() => {
+		return (
+			<Box
+				sx={{
+					display: 'flex',
+					gap: '.25rem',
+					flexWrap: 'wrap',
+					justifyContent: 'flex-start',
+					alignItems: 'center',
+				}}
+			>
+				<Box
+					sx={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '.25rem',
+					}}
+				>
+					<Person />
+					<span>{`${item?.members.length} ${item?.members.length > 1 ? 'Members' : 'Member'} `}</span>
+				</Box>
+				<Box
+					sx={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '.25rem',
+					}}
+				>
+					{item.members.find((member) => member.identity.id === address) ? (
+						<>
+							<span>
+								<Check />
+							</span>
+							<span>{'Joined'}</span>
+						</>
+					) : (
+						<>
+							<span>{item?.access === 0 ? <KeyOff /> : <Key />}</span>
+							<span>{item?.access === 0 ? 'Public' : 'Private'}</span>
+						</>
+					)}
+				</Box>
+			</Box>
+		)
+	}, [item, address])
+
+	return (
+		<NavLink href={`${toLink}${item.id}`}>
+			<Card
+				sx={{
+					minHeight: '184px',
+					borderRadius: '16px',
+					'&:hover': { borderColor: 'primary.main' },
+					...bgPlain,
+				}}
+			>
+				<CardHeader
+					avatar={
+						<Avatar src={`${gateway}${metadata?.logo}`} sx={{ width: 64, height: 64 }}>
+							{item?.name.slice(0, 1)}
+						</Avatar>
+					}
+					title={<Typography noWrap>{item?.name}</Typography>}
+					subheader={SubHeader}
+				/>
+				<CardContent>
+					<Typography
+						sx={{
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							display: '-webkit-box',
+							'-webkit-line-clamp': '2',
+							'-webkit-box-orient': 'vertical',
+						}}
+					>
+						{metadata?.description}
+					</Typography>
+				</CardContent>
+			</Card>
+		</NavLink>
+	)
+}

--- a/pkg/app/src/components/OrganisationCard/modules/tileCard.tsx
+++ b/pkg/app/src/components/OrganisationCard/modules/tileCard.tsx
@@ -4,7 +4,7 @@ import { NavLink } from 'src/components/NavLink/navLink'
 import { BodyData } from 'src/@types/bodydata'
 import { IpfsMetadata } from 'src/@types/ipfsmetadata'
 import { useTheme } from '@mui/material/styles'
-import { Typography, Card, Box, CardHeader, CardContent, Avatar } from '@mui/material'
+import { Typography, Card, Box, CardHeader, CardContent, Avatar, CircularProgress } from '@mui/material'
 import { Person, Key, KeyOff, Check } from '@mui/icons-material'
 
 interface ComponentsPros {
@@ -67,14 +67,23 @@ export const TileCard = ({ item, metadata }: ComponentsPros) => {
 		)
 	}, [item, address])
 
+	if (!item || !metadata) {
+		return (
+			<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+				<CircularProgress color="inherit" />
+			</Box>
+		)
+	}
+
 	return (
 		<NavLink href={`${toLink}${item.id}`}>
 			<Card
 				sx={{
 					minHeight: '184px',
 					borderRadius: '16px',
-					'&:hover': { borderColor: 'primary.main' },
+					'&:hover': { background: theme.palette.grey[500_32] },
 					...bgPlain,
+					cursor: 'pointer',
 				}}
 			>
 				<CardHeader

--- a/pkg/app/src/components/OrganisationCard/modules/tileCard.tsx
+++ b/pkg/app/src/components/OrganisationCard/modules/tileCard.tsx
@@ -67,14 +67,6 @@ export const TileCard = ({ item, metadata }: ComponentsPros) => {
 		)
 	}, [item, address])
 
-	if (!item || !metadata) {
-		return (
-			<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-				<CircularProgress color="inherit" />
-			</Box>
-		)
-	}
-
 	return (
 		<NavLink href={`${toLink}${item.id}`}>
 			<Card
@@ -86,28 +78,36 @@ export const TileCard = ({ item, metadata }: ComponentsPros) => {
 					cursor: 'pointer',
 				}}
 			>
-				<CardHeader
-					avatar={
-						<Avatar src={`${gateway}${metadata?.logo}`} sx={{ width: 64, height: 64 }}>
-							{item?.name.slice(0, 1)}
-						</Avatar>
-					}
-					title={<Typography noWrap>{item?.name}</Typography>}
-					subheader={SubHeader}
-				/>
-				<CardContent>
-					<Typography
-						sx={{
-							overflow: 'hidden',
-							textOverflow: 'ellipsis',
-							display: '-webkit-box',
-							'-webkit-line-clamp': '2',
-							'-webkit-box-orient': 'vertical',
-						}}
-					>
-						{metadata?.description}
-					</Typography>
-				</CardContent>
+				{!item || !metadata ? (
+					<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+						<CircularProgress color="inherit" />
+					</Box>
+				) : (
+					<>
+						<CardHeader
+							avatar={
+								<Avatar src={`${gateway}${metadata?.logo}`} sx={{ width: 64, height: 64 }}>
+									{item?.name.slice(0, 1)}
+								</Avatar>
+							}
+							title={<Typography noWrap>{item?.name}</Typography>}
+							subheader={SubHeader}
+						/>
+						<CardContent>
+							<Typography
+								sx={{
+									overflow: 'hidden',
+									textOverflow: 'ellipsis',
+									display: '-webkit-box',
+									'-webkit-line-clamp': '2',
+									'-webkit-box-orient': 'vertical',
+								}}
+							>
+								{metadata?.description}
+							</Typography>
+						</CardContent>
+					</>
+				)}
 			</Card>
 		</NavLink>
 	)

--- a/pkg/app/src/layouts/default/modules/sidebar.tsx
+++ b/pkg/app/src/layouts/default/modules/sidebar.tsx
@@ -91,6 +91,17 @@ export function Sidebar({ showHeader, onClose, open, variant }: ComponentProps) 
 					<SidebarNavItem href="/app" name="dashboard">
 						{t('button:navigation:dashboard')}
 					</SidebarNavItem>
+					<SidebarNavItem href="/app/organisations" name="organisation">
+						Organisations
+						{counter.gov > 0 && (
+							<NavBadge
+								sx={{ ml: '0.5rem' }}
+								badgeContent={counter.gov}
+								color={'primary'}
+								variant="dot"
+							/>
+						)}
+					</SidebarNavItem>
 					<SidebarNavItem href="/app/governance" name="voting">
 						{t('button:navigation:governance')}
 						{counter.gov > 0 && (

--- a/pkg/app/src/pages/app/organisations/[id].tsx
+++ b/pkg/app/src/pages/app/organisations/[id].tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import Box from '@mui/material/Box'
+import Paper from '@mui/material/Paper'
+import Typography from '@mui/material/Typography'
+
+import { Layout } from 'src/layouts/default/layout'
+
+export function OrganisationById() {
+	return (
+		<Layout showHeader showFooter showSidebar title="Organisations">
+			<Box sx={{ p: '4rem', height: '90vh' }}>
+				<Paper sx={{ p: '4rem', height: '100%', borderRadius: '.5rem' }} elevation={10}>
+					<Typography sx={{ fontWeight: '800' }} variant={'h2'}>
+						Organisation Detail
+					</Typography>
+				</Paper>
+			</Box>
+		</Layout>
+	)
+}
+
+export default OrganisationById

--- a/pkg/app/src/pages/app/organisations/index.tsx
+++ b/pkg/app/src/pages/app/organisations/index.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react'
+import Box from '@mui/material/Box'
+import Paper from '@mui/material/Paper'
+import Typography from '@mui/material/Typography'
+
+import { ItemList } from 'components/OrganisationCard/itemList'
+import { Layout } from 'src/layouts/default/layout'
+import { useBodiesQuery } from '@gamedao-haiku/graphql/dist'
+import { CircularProgress } from '@mui/material'
+
+export function OrganisationPage() {
+	const { loading, error, data } = useBodiesQuery()
+	console.log('data------>', data)
+	useEffect(() => {
+		if (error) {
+			console.error('There is an error when querying the display values')
+		}
+	}, [error])
+
+	return (
+		<Layout showHeader showFooter showSidebar title="Organisation">
+			<Box sx={{ p: { sx: '.5rem', sm: '1rem', lg: '4rem' }, minHeight: '90vh' }}>
+				<Paper
+					sx={{ p: { sx: '.5rem', sm: '1rem', lg: '4rem' }, height: '100%', borderRadius: '.5rem' }}
+					elevation={10}
+				>
+					<Typography sx={{ fontWeight: '800' }} variant={'h2'}>
+						Hello. Bodies count: {loading ? <CircularProgress /> : data?.bodies.length}
+					</Typography>
+					{<ItemList items={data?.bodies}></ItemList>}
+				</Paper>
+			</Box>
+		</Layout>
+	)
+}
+
+export default OrganisationPage

--- a/pkg/app/src/pages/app/organisations/index.tsx
+++ b/pkg/app/src/pages/app/organisations/index.tsx
@@ -10,7 +10,6 @@ import { CircularProgress } from '@mui/material'
 
 export function OrganisationPage() {
 	const { loading, error, data } = useBodiesQuery()
-	console.log('data------>', data)
 	useEffect(() => {
 		if (error) {
 			console.error('There is an error when querying the display values')

--- a/pkg/graphql/src/schema/queries/bodies.graphql
+++ b/pkg/graphql/src/schema/queries/bodies.graphql
@@ -7,5 +7,7 @@ query Bodies {
                 id
             }
         }
+        cid
+        access
     }
 }


### PR DESCRIPTION
- the page /app/organisations results in a list page with organisations listed in organisation cards
- each card represents an organisation (body) and has following elements:
- -  Logo 
- - member count with icon
- - public, private or exclusive label with icon
- - description which is cut after 2 lines of description and followed by "..."
- - membership states: when wallet is connected and the user is member, the user can see a "joined" label
- On click of the organisation card the user gets to the Organisation Detail page (see beta for reference)
- Org List Page is sorted by creation date (oldest on top)