### PR TITLE
fix(style): organization details header image

### DIFF
--- a/pkg/app/src/pages/organisations/[...param].tsx
+++ b/pkg/app/src/pages/organisations/[...param].tsx
@@ -27,11 +27,11 @@ import { parseIpfsHash, uploadFileToIpfs } from 'src/utils/ipfs'
 import { createWarningNotification } from 'src/utils/notificationUtils'
 
 import { Layout } from 'components/Layouts/default/layout'
+import { CampaignOverview } from 'components/TabPanels/Campaign/overview'
 import { Overview } from 'components/TabPanels/Organization/overview'
 import { TmpOverview } from 'components/TabPanels/Organization/tmpOverview'
 import { ProposalDetail } from 'components/TabPanels/Proposal/detail'
 import { ProposalOverview } from 'components/TabPanels/Proposal/overview'
-import { CampaignOverview } from 'components/TabPanels/Campaign/overview'
 
 export function OrganisationById() {
 	const { query, push } = useRouter()
@@ -147,8 +147,8 @@ export function OrganisationById() {
 								<Grid
 									minHeight="20vh"
 									maxHeight="20vh"
+									width="100%"
 									display="grid"
-									justifyContent="center"
 									alignItems="center"
 									overflow="hidden"
 								>
@@ -162,7 +162,9 @@ export function OrganisationById() {
 										/>
 										{!organizationState?.organization_metadata?.header &&
 										!tmpOrg.headerCID?.length ? (
-											<AddAPhoto sx={{ height: '44px', width: '44px', cursor: 'pointer' }} />
+											<Box display="grid" justifyContent="center" alignItems="center">
+												<AddAPhoto sx={{ height: '44px', width: '44px', cursor: 'pointer' }} />
+											</Box>
 										) : (
 											<CardMedia
 												component="img"


### PR DESCRIPTION
### Related to issue #193

**Done:** 

- Fixed the style of the image header in the organization detail page

**How To Test:**

- Navigate to an organization page and check the header image, it should be stretched

### **Preview:**

## Before:

<img width="1098" alt="Screen Shot 2022-07-06 at 11 22 17 AM" src="https://user-images.githubusercontent.com/67205042/177504819-4f5d0bce-e7fa-4439-9246-c8b02d0ee676.png">


## After

**Organization with a header image:**

<img width="1140" alt="Screen Shot 2022-07-06 at 11 17 55 AM" src="https://user-images.githubusercontent.com/67205042/177503983-0be01bd1-b311-43c5-9021-43736bfe9b06.png">

**Organization without header image:**

<img width="1202" alt="Screen Shot 2022-07-06 at 11 19 13 AM" src="https://user-images.githubusercontent.com/67205042/177504221-a519ff41-8f5d-4b08-b318-60010d5823b5.png">
