### PR TITLE
fix: update the collectable size

### DIFF
--- a/pkg/app/src/components/Collectable/collectable.tsx
+++ b/pkg/app/src/components/Collectable/collectable.tsx
@@ -63,13 +63,15 @@ const Collectable: FC<ComponentProps> = ({ item }) => {
 							</Typography>
 						</Box>
 					</CardContent>
-					<ModelDialog
-						open={openModel}
-						mediaUrl={ipfsMetadata.mediaUri}
-						handleClose={() => setOpenModel(false)}
-						poster={parseIpfsHash(ipfsMetadata.thumbnailUri, RMRK_GATEWAY)}
-						alt={ipfsMetadata.description}
-					/>
+					<Box display="flex" justifyContent="center" alignItems="center">
+						<ModelDialog
+							open={openModel}
+							mediaUrl={ipfsMetadata.mediaUri}
+							handleClose={() => setOpenModel(false)}
+							poster={parseIpfsHash(ipfsMetadata.thumbnailUri, RMRK_GATEWAY)}
+							alt={ipfsMetadata.description}
+						/>
+					</Box>
 				</Card>
 			) : (
 				<LoadingCollectableCard />

--- a/pkg/app/src/components/Collectable/modules/modelDialog.tsx
+++ b/pkg/app/src/components/Collectable/modules/modelDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { Box, Dialog, Paper } from '@mui/material'
+import { Box, Dialog } from '@mui/material'
 import { fetchIpfsBlob } from 'src/utils/ipfs'
 
 interface ComponentProps {
@@ -51,49 +51,71 @@ export function ModelDialog({ open, mediaUrl, handleClose, alt, poster }: Compon
 	}, [open])
 
 	return (
-		<Dialog open={open} onClose={handleClose}>
-			<Paper>
-				<Box padding={4}>
-					{is3DModel && (
-						<>
-							{/* @ts-ignore */}
-							<model-viewer
-								src={fileState}
-								ios-src=""
-								poster={poster}
-								alt={alt}
-								shadow-intensity="1"
-								camera-controls
-								auto-rotate
-								ar
-							/>
-						</>
-					)}
+		<Dialog
+			sx={{
+				pt: { xs: '7rem', md: '12rem', lg: '22rem' },
+				pl: { md: '5rem' },
 
-					{isImage && (
-						<Box
-							sx={{
-								width: '100%',
-							}}
-							component="img"
-							src={fileState ?? poster}
+				'& .MuiDialog-container': {
+					'& .MuiPaper-root': {
+						width: '100%',
+						maxWidth: { sm: '68rem' },
+						height: '100%',
+						maxHeight: { xs: '20rem', sm: '40rem' },
+					},
+				},
+			}}
+			open={open}
+			onClose={handleClose}
+		>
+			<Box padding={4}>
+				{is3DModel && (
+					<Box
+						sx={{
+							display: 'flex',
+							justifyContent: 'center',
+							alignItems: 'center',
+							width: '100%',
+							height: '100%',
+						}}
+					>
+						{/* @ts-ignore */}
+						<model-viewer
+							src={fileState}
+							ios-src=""
+							poster={poster}
 							alt={alt}
+							shadow-intensity="1"
+							camera-controls
+							auto-rotate
+							ar
 						/>
-					)}
+					</Box>
+				)}
 
-					{isVideo && (
-						<Box
-							sx={{
-								width: '100%',
-							}}
-						>
-							<video width="320" height="240" controls>
-								<source src={fileState} type={isVideo} />
-							</video>
-						</Box>
-					)}
-				</Box>
-			</Paper>
+				{isImage && (
+					<Box
+						sx={{
+							width: '100%',
+						}}
+						component="img"
+						src={fileState ?? poster}
+						alt={alt}
+					/>
+				)}
+
+				{isVideo && (
+					<Box
+						sx={{
+							width: '100%',
+						}}
+					>
+						<video width="320" height="240" controls>
+							<source src={fileState} type={isVideo} />
+						</video>
+					</Box>
+				)}
+			</Box>
 		</Dialog>
 	)
 }

--- a/pkg/app/src/pages/_app.tsx
+++ b/pkg/app/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import 'react-toastify/dist/ReactToastify.css'
 import { Providers } from 'src/provider/provider'
 import createEmotionCache from 'src/theme/createEmotionCache'
 import 'src/theme/css/toastify.css'
+import 'src/theme/css/modelViewer.css'
 
 const clientSideEmotionCache = createEmotionCache()
 

--- a/pkg/app/src/theme/css/modelViewer.css
+++ b/pkg/app/src/theme/css/modelViewer.css
@@ -1,0 +1,14 @@
+@media only screen and (min-device-width: 360px){
+    model-viewer{
+        width: 20rem;
+        height: 15rem;
+    }
+}
+
+
+@media only screen and (min-device-width: 480px){
+    model-viewer{
+        width: 35rem;
+        height: 32rem;
+    }
+}

--- a/pkg/app/src/theme/overrides/Dialog.ts
+++ b/pkg/app/src/theme/overrides/Dialog.ts
@@ -9,7 +9,7 @@ export default function Dialog(theme: Theme) {
 				paper: {
 					boxShadow: theme.customShadows.dialog,
 					'&.MuiPaper-rounded': {
-						borderRadius: Number(theme.shape.borderRadius) * 2,
+						borderRadius: Number(theme.shape.borderRadius) * 20,
 					},
 					'&.MuiDialog-paperFullScreen': {
 						borderRadius: 0,


### PR DESCRIPTION
### Related to issue #233 

Done:

Updated model viewer to display the collectable nft in a larger size.

How to test:

1. navigate to the collectables tab in the account page
2. Click on your beta key

Before:
<img width="1727" alt="Screen Shot 2022-07-06 at 1 57 08 PM" src="https://user-images.githubusercontent.com/74880499/177535322-6a14c17a-d91d-4164-8f68-90d45e469ac2.png">

After:
on Desktop:

<img width="1728" alt="Screen Shot 2022-07-06 at 2 00 15 PM" src="https://user-images.githubusercontent.com/74880499/177535690-e375a9d2-35b1-48ff-a518-8145c7cc6185.png">

on mobile
<img width="1728" alt="Screen Shot 2022-07-06 at 2 01 13 PM" src="https://user-images.githubusercontent.com/74880499/177535870-60e3f261-fdc9-40ba-a775-0f488823133e.png">

on Ipad:
<img width="1728" alt="Screen Shot 2022-07-06 at 2 01 48 PM" src="https://user-images.githubusercontent.com/74880499/177535978-b6116f58-7728-4b61-a13b-b39eee86ce42.png">

