### PR TITLE
feat: organization no campaigns

### DIFF
--- a/pkg/app/src/components/TabPanels/Campaign/overview.tsx
+++ b/pkg/app/src/components/TabPanels/Campaign/overview.tsx
@@ -1,5 +1,9 @@
-import { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 
+import { useRouter } from 'next/router'
+
+import { Box, Button, Typography } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import { Campaign, useCampaignByOrganizationIdSubscription } from 'src/queries'
 
 import { CampaignsList } from 'components/CampaignsList/campaignsList'
@@ -14,6 +18,12 @@ export function CampaignOverview({ organizationId, isAdmin }: ComponentProps) {
 	const { data, loading } = useCampaignByOrganizationIdSubscription({
 		variables: { orgId: organizationId },
 	})
+	const { t } = useTranslation()
+	const { push } = useRouter()
+	const rerouteToCampaigns = useCallback(() => {
+		push('/campaigns')
+	}, [push])
+
 	const paginatedData = useMemo<Campaign[]>(() => data?.campaign?.slice() as Campaign[], [data])
 	const [showCreatePage, setShowCreatePage] = useState<boolean>(false)
 
@@ -28,15 +38,33 @@ export function CampaignOverview({ organizationId, isAdmin }: ComponentProps) {
 	if (showCreatePage) {
 		return <CreateCampaignPage organizationId={organizationId} cancel={onHandleCancelClicked} />
 	}
-
-	return (
-		<>
-			<CampaignsList
-				campaigns={paginatedData}
-				loading={loading}
-				showCreate={isAdmin}
-				createCallback={onCreateCallback}
-			/>
-		</>
+	return !loading && paginatedData?.length ? (
+		<CampaignsList
+			campaigns={paginatedData}
+			loading={loading}
+			showCreate={isAdmin}
+			createCallback={onCreateCallback}
+		/>
+	) : (
+		<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+			<Box
+				sx={{
+					display: 'flex',
+					flexDirection: 'column',
+					alignContent: 'space-evenly',
+					alignItems: 'center',
+				}}
+			>
+				<Typography variant="subtitle1">{t('page:organisations:no_campaigns')}</Typography>
+				<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'space-evenly', mt: 2 }}>
+					{isAdmin && (
+						<Button variant="contained" onClick={onCreateCallback}>
+							{t('button:ui:create_campaign')}
+						</Button>
+					)}
+					<Button onClick={rerouteToCampaigns}>{t('button:ui:explore_campaigns')}</Button>
+				</Box>
+			</Box>
+		</Box>
 	)
 }

--- a/pkg/translations/src/app/en-US.json
+++ b/pkg/translations/src/app/en-US.json
@@ -21,7 +21,9 @@
         "transaction_fee": "Transaction Fee",
         "your_balance": "Your current balance",
         "description_toggle": "What is this used for?"
-      }
+      },
+      "create_campaign": "Create your first Campaign",
+      "explore_campaigns": "Explore Campaigns"
     },
     "form": {
       "next_step": "Next step",
@@ -84,6 +86,7 @@
   },
   "page": {
     "organisations": {
+      "no_campaigns": "No Campaigns Yet",
       "no_organisations": "No organisation found",
       "no_result": "No results found for {{query}} Try checking for typos or using a different term.",
       "search_place_holder": "Search Organizations",


### PR DESCRIPTION
### closes #249 

## How to Test:

- Navigate to an organization page with no campaigns and check the new user interface
- Check your organization with no campaigns

## Screenshots:

### Organization with no campaigns (**Admin**):
![Screen Shot 2022-07-18 at 5 24 06 PM](https://user-images.githubusercontent.com/67205042/179533394-76a95bf5-f9b6-41de-8499-49db0e716ea1.png)

### Organization with no campaigns (**Regular User**):
<img width="1113" alt="Screen Shot 2022-07-18 at 5 24 22 PM" src="https://user-images.githubusercontent.com/67205042/179533474-a7559eed-0589-4f86-b095-7954524e1df6.png">