### PR TITLE
fix(graphql): organization member sort

### DIFF
--- a/pkg/service/package.json
+++ b/pkg/service/package.json
@@ -40,7 +40,7 @@
     "graphql-import-node": "^0.0.5",
     "graphql-request": "^4.3.0",
     "graphql-subscriptions": "^2.0.0",
-    "graphql-upload": "15.0.2",
+    "graphql-upload": "13.0.0",
     "graphql-ws": "^5.9.1",
     "ipfs-http-client": "^57.0.1",
     "prisma": "^4.1.0",

--- a/pkg/service/src/resolvers/query/displayValues/data.json
+++ b/pkg/service/src/resolvers/query/displayValues/data.json
@@ -266,13 +266,13 @@
   "organizationSortOptions": [
     {
       "text": "page:organisations:sort_options:mem_hi_lo",
-      "key": "memberLimit_DESC",
-      "value": "{ member_limit: 'desc' }"
+      "key": "memberCount_DESC",
+      "value": "{ 'orderBy': { 'organization_members_aggregate': { 'count': 'desc'} } }"
     },
     {
       "text": "page:organisations:sort_options:mem_lo_hi",
-      "key": "memberLimit_ASC",
-      "value": "{ member_limit: 'asc' }"
+      "key": "memberCount_ASC",
+      "value": "{ 'orderBy': { 'organization_members_aggregate': { 'count': 'asc'} } }"
     },
     {
       "text": "page:organisations:sort_options:created_new",


### PR DESCRIPTION
### closes #291

### Overview:
 
Switched the order by query, instead of ordering by the member limit for an organization, it now order by the count of members in an organization