### PR TITLE
feat(update-dev-env-prune-node): updated parachain-a to full node

### DIFF
--- a/pkg/dev-env/docker-compose.yml
+++ b/pkg/dev-env/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       - "--ws-port=9944"
       - "--unsafe-ws-external"
       - "--rpc-cors=all"
+      - "--pruning=archive"
       - "--bootnodes=/dns/subzero-relay-a/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
     volumes:
       - "./node/chainspec:/chainspec"


### PR DESCRIPTION
updated docker-compose service "zero-parachain-a" to full node.
now it shouldn't discard any blocks.