### PR TITLE
feat: updated ipfs urls to use proxy

### DIFF
--- a/pkg/app/src/utils/ipfs.ts
+++ b/pkg/app/src/utils/ipfs.ts
@@ -1,11 +1,11 @@
 import { CID, create } from 'ipfs-http-client'
 import { createErrorNotification } from 'src/utils/notificationUtils'
 
-const GATEWAY = 'https://ipfs.sub.zero.io/ipfs/'
+const GATEWAY = 'https://ipfs.sub.zero.io/'
 
 export function parseIpfsHash(ipfsHash: string, gateway: string = GATEWAY) {
 	const hashPart = ipfsHash?.split('/')
-	return `${gateway}${hashPart?.[hashPart?.length - 1]}`
+	return `${gateway}/ipfs/${hashPart?.[hashPart?.length - 1]}`
 }
 
 export async function fetchIpfsJson(ipfsHash: string, gateway: string = GATEWAY) {

--- a/pkg/app/src/utils/ipfs.ts
+++ b/pkg/app/src/utils/ipfs.ts
@@ -1,12 +1,14 @@
 import { CID, create } from 'ipfs-http-client'
 import { createErrorNotification } from 'src/utils/notificationUtils'
 
-export function parseIpfsHash(ipfsHash: string, gateway: string = 'https://gateway.ipfs.io/') {
-	let hashPart = ipfsHash?.split('/')
-	return gateway + 'ipfs/' + hashPart?.[hashPart?.length - 1]
+const GATEWAY = 'https://ipfs.sub.zero.io/ipfs/'
+
+export function parseIpfsHash(ipfsHash: string, gateway: string = GATEWAY) {
+	const hashPart = ipfsHash?.split('/')
+	return `${gateway}${hashPart?.[hashPart?.length - 1]}`
 }
 
-export async function fetchIpfsJson(ipfsHash: string, gateway: string = 'https://gateway.ipfs.io/') {
+export async function fetchIpfsJson(ipfsHash: string, gateway: string = GATEWAY) {
 	try {
 		const response = await fetch(parseIpfsHash(ipfsHash, gateway), { method: 'GET' })
 		return await response.json()
@@ -17,7 +19,7 @@ export async function fetchIpfsJson(ipfsHash: string, gateway: string = 'https:/
 	return null
 }
 
-export async function fetchIpfsBlob(ipfsHash: string, gateway: string = 'https://gateway.ipfs.io/') {
+export async function fetchIpfsBlob(ipfsHash: string, gateway: string = GATEWAY) {
 	try {
 		const response = await fetch(parseIpfsHash(ipfsHash, gateway), { method: 'GET' })
 		return await response.blob()

--- a/pkg/service/src/resolvers/query/config/config.json
+++ b/pkg/service/src/resolvers/query/config/config.json
@@ -8,7 +8,7 @@
     "TW_SITE_CREATOR": "@zerodotio",
     "TW_SITE_IMAGE": "https://gamedao.co/img/tw-preview.jpg",
     "CONTACT": "hey@gamedao.co",
-    "IPFS_GATEWAY": "https://gamedao.infura-ipfs.io/",
+    "IPFS_GATEWAY": "https://ipfs.sub.zero.io/",
     "LOG_LEVEL": "INFO",
     "PROPOSAL_MIN_EXPIRY_IN_SECONDS": 300,
     "CAMPAIGN_MIN_EXPIRY_IN_SECONDS": 300


### PR DESCRIPTION
closes #388 

@2075 @vovacha
The images won't work because the URL path has changed.
Haiku loads it from the Service, that means we need to deploy the Service first with the updated URL to make the images work again.